### PR TITLE
new build process for monolith

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -10,17 +10,21 @@ set -e
 
 mkdir -p $GOPATH/src/github.com/convox
 cd $GOPATH/src/github.com/convox
-git_clone cli
+git_clone rack
+
+# replace the Version "dev" with our tagged release version
 
 tag=$(date +%Y%m%d%H%M%S)
 
-sed -i -e "s/\"dev\"/\"${tag}\"/g" convox/main.go
+sed -i -e "s/\"dev\"/\"${tag}\"/g" cmd/convox/main.go
 
-/go/bin/go-bindata -o convox/asset.go -prefix convox convox/data
+make convox
+
+# /go/bin/go-bindata -o cmd/convox/asset.go -prefix convox cmd/convox/data
 
 equinox release --equinox-account=$EQUINOX_ACCOUNT --equinox-secret=$EQUINOX_SECRET \
   --equinox-app=$EQUINOX_APP --channel=stable \
-  --platforms="linux_386 linux_amd64 darwin_amd64" --version=$tag ./convox
+  --platforms="linux_386 linux_amd64 darwin_amd64" --version=$tag /go/bin/convox
 
 echo "cli released: $tag"
 


### PR DESCRIPTION
of note:

- not making a call to `go-bindata` anymore. assuming this is already done and committed to source.
- using `make convox` to build the binary